### PR TITLE
Infinite loop in stratum response parsing.

### DIFF
--- a/src/stratum/stratum.cpp
+++ b/src/stratum/stratum.cpp
@@ -527,6 +527,7 @@ namespace merit
                     throw std::runtime_error("disconnected.");
                 }
                 if(!handle_command(res)) {
+                    _sockbuf.clear();
                     continue;
                 }
             } catch(std::exception& e) {

--- a/src/stratum/stratum.hpp
+++ b/src/stratum/stratum.hpp
@@ -104,7 +104,7 @@ namespace merit
                 bool recv(std::string&);
                 void cleanup();
                 bool subscribe_resp();
-                bool handle_command(const std::string& res);
+                bool handle_command(const pt::ptree&, const std::string& res);
                 bool mining_notify(const pt::ptree& params);
                 bool mining_difficulty(const pt::ptree& params);
                 bool client_reconnect(const pt::ptree& params);


### PR DESCRIPTION
If the stratum server sent any non json parsible line the client would get in an infinite loop trying to parse the garbage line.

Also if the stratum server requests a reconnect, the client didn't properly reconnect.