### PR TITLE
Fix SetupKernelBuffers call.

### DIFF
--- a/include/merit/miner.hpp
+++ b/include/merit/miner.hpp
@@ -26,7 +26,7 @@ namespace merit
     void disconnect_stratum(Context* c);
     bool is_stratum_connected(Context* c);
 
-    void init_logging();
+    void init();
     bool run_stratum(Context*);
     void stop_stratum(Context*);
 

--- a/src/cuckoo/gpu/kernel.cu
+++ b/src/cuckoo/gpu/kernel.cu
@@ -833,8 +833,8 @@ int CudaDevices()
     return count;
 }
 
-int SetupBuffers() {
-    int count = CudaDevices();
+int SetupKernelBuffers() {
+    const int count = CudaDevices();
 
     if(!buffer_a.empty()) {
         return count;
@@ -855,8 +855,6 @@ int SetupBuffers() {
     return count;
 }
 
-const int TOTAL_DEVICES = SetupBuffers();
-
 using Cycle = std::set<uint32_t>;
 
 template <class offset_t, uint8_t EDGEBITS, uint8_t XBITS>
@@ -871,7 +869,7 @@ struct Run
             int device)
     {
         assert(device >= 0);
-        assert(device < TOTAL_DEVICES);
+        assert(device < buffer_a.size());
 
         std::vector<u64> buffer(150000);
 

--- a/src/minerd.cpp
+++ b/src/minerd.cpp
@@ -49,6 +49,8 @@ std::pair<int, int> determine_utilization(int cores)
 
 int main(int argc, char** argv) 
 {
+    merit::init();
+
     po::options_description desc("Allowed options");
     std::string url;
     std::vector<int> gpu_devices;

--- a/src/public.cpp
+++ b/src/public.cpp
@@ -38,6 +38,9 @@
 #include <atomic>
 #include <chrono>
 
+//forward declare SetupBuffers which is in kernel.cu
+int SetupKernelBuffers();
+
 namespace merit
 {
 
@@ -121,8 +124,9 @@ namespace merit
         return c->stratum.connected();
     }
     
-    void init_logging()
+    void init()
     {
+        ::SetupKernelBuffers();
     }
 
     bool run_stratum(Context* c)
@@ -314,6 +318,7 @@ namespace merit
     std::vector<merit::GPUInfo> gpus_info(){
         return miner::GPUInfo();
     };
+
 
 }
 


### PR DESCRIPTION
The old SetupBuffers call needs to be called after main. Now it is
called in the new merit::init function. This fixes a crash on windows
builds.