### PR TITLE
Colorize output using termcolor

### DIFF
--- a/include/merit/termcolor/termcolor.hpp
+++ b/include/merit/termcolor/termcolor.hpp
@@ -1,0 +1,557 @@
+//!
+//! termcolor
+//! ~~~~~~~~~
+//!
+//! termcolor is a header-only c++ library for printing colored messages
+//! to the terminal. Written just for fun with a help of the Force.
+//!
+//! :copyright: (c) 2013 by Ihor Kalnytskyi
+//! :license: BSD, see LICENSE for details
+//!
+
+#ifndef TERMCOLOR_HPP_
+#define TERMCOLOR_HPP_
+
+// the following snippet of code detects the current OS and
+// defines the appropriate macro that is used to wrap some
+// platform specific things
+#if defined(_WIN32) || defined(_WIN64)
+#   define TERMCOLOR_OS_WINDOWS
+#elif defined(__APPLE__)
+#   define TERMCOLOR_OS_MACOS
+#elif defined(__unix__) || defined(__unix)
+#   define TERMCOLOR_OS_LINUX
+#else
+#   error unsupported platform
+#endif
+
+
+// This headers provides the `isatty()`/`fileno()` functions,
+// which are used for testing whether a standart stream refers
+// to the terminal. As for Windows, we also need WinApi funcs
+// for changing colors attributes of the terminal.
+#if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+#   include <unistd.h>
+#elif defined(TERMCOLOR_OS_WINDOWS)
+#   include <io.h>
+#   include <windows.h>
+#endif
+
+
+#include <iostream>
+#include <cstdio>
+
+
+
+namespace termcolor
+{
+    // Forward declaration of the `_internal` namespace.
+    // All comments are below.
+    namespace _internal
+    {
+        // An index to be used to access a private storage of I/O streams. See
+        // colorize / nocolorize I/O manipulators for details.
+        static int colorize_index = std::ios_base::xalloc();
+
+        inline FILE* get_standard_stream(const std::ostream& stream);
+        inline bool is_colorized(std::ostream& stream);
+        inline bool is_atty(const std::ostream& stream);
+
+    #if defined(TERMCOLOR_OS_WINDOWS)
+        inline void win_change_attributes(std::ostream& stream, int foreground, int background=-1);
+    #endif
+    }
+
+    inline
+    std::ostream& colorize(std::ostream& stream)
+    {
+        stream.iword(_internal::colorize_index) = 1L;
+        return stream;
+    }
+
+    inline
+    std::ostream& nocolorize(std::ostream& stream)
+    {
+        stream.iword(_internal::colorize_index) = 0L;
+        return stream;
+    }
+
+    inline
+    std::ostream& reset(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[00m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1, -1);
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& bold(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[1m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& dark(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[2m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& underline(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[4m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& blink(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[5m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& reverse(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[7m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& concealed(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[8m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& grey(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[30m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                0   // grey (black)
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& red(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[31m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& green(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[32m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_GREEN
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& yellow(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[33m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_GREEN | FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& blue(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[34m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& magenta(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[35m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE | FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& cyan(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[36m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE | FOREGROUND_GREEN
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& white(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[37m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+
+
+    inline
+    std::ostream& on_grey(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[40m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                0   // grey (black)
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_red(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[41m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_green(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[42m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_yellow(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[43m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN | BACKGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_blue(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[44m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_BLUE
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_magenta(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[45m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_BLUE | BACKGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_cyan(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[46m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN | BACKGROUND_BLUE
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_white(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[47m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_RED
+            );
+        #endif
+        }
+
+        return stream;
+    }
+
+
+
+    //! Since C++ hasn't a way to hide something in the header from
+    //! the outer access, I have to introduce this namespace which
+    //! is used for internal purpose and should't be access from
+    //! the user code.
+    namespace _internal
+    {
+        //! Since C++ hasn't a true way to extract stream handler
+        //! from the a given `std::ostream` object, I have to write
+        //! this kind of hack.
+        inline
+        FILE* get_standard_stream(const std::ostream& stream)
+        {
+            if (&stream == &std::cout)
+                return stdout;
+            else if ((&stream == &std::cerr) || (&stream == &std::clog))
+                return stderr;
+
+            return 0;
+        }
+
+        // Say whether a given stream should be colorized or not. It's always
+        // true for ATTY streams and may be true for streams marked with
+        // colorize flag.
+        inline
+        bool is_colorized(std::ostream& stream)
+        {
+            return is_atty(stream) || static_cast<bool>(stream.iword(colorize_index));
+        }
+
+        //! Test whether a given `std::ostream` object refers to
+        //! a terminal.
+        inline
+        bool is_atty(const std::ostream& stream)
+        {
+            FILE* std_stream = get_standard_stream(stream);
+
+            // Unfortunately, fileno() ends with segmentation fault
+            // if invalid file descriptor is passed. So we need to
+            // handle this case gracefully and assume it's not a tty
+            // if standard stream is not detected, and 0 is returned.
+            if (!std_stream)
+                return false;
+
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            return ::isatty(fileno(std_stream));
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            return ::_isatty(_fileno(std_stream));
+        #endif
+        }
+
+    #if defined(TERMCOLOR_OS_WINDOWS)
+        //! Change Windows Terminal colors attribute. If some
+        //! parameter is `-1` then attribute won't changed.
+        inline void win_change_attributes(std::ostream& stream, int foreground, int background)
+        {
+            // yeah, i know.. it's ugly, it's windows.
+            static WORD defaultAttributes = 0;
+
+            // Windows doesn't have ANSI escape sequences and so we use special
+            // API to change Terminal output color. That means we can't
+            // manipulate colors by means of "std::stringstream" and hence
+            // should do nothing in this case.
+            if (!_internal::is_atty(stream))
+                return;
+
+            // get terminal handle
+            HANDLE hTerminal = INVALID_HANDLE_VALUE;
+            if (&stream == &std::cout)
+                hTerminal = GetStdHandle(STD_OUTPUT_HANDLE);
+            else if (&stream == &std::cerr)
+                hTerminal = GetStdHandle(STD_ERROR_HANDLE);
+
+            // save default terminal attributes if it unsaved
+            if (!defaultAttributes)
+            {
+                CONSOLE_SCREEN_BUFFER_INFO info;
+                if (!GetConsoleScreenBufferInfo(hTerminal, &info))
+                    return;
+                defaultAttributes = info.wAttributes;
+            }
+
+            // restore all default settings
+            if (foreground == -1 && background == -1)
+            {
+                SetConsoleTextAttribute(hTerminal, defaultAttributes);
+                return;
+            }
+
+            // get current settings
+            CONSOLE_SCREEN_BUFFER_INFO info;
+            if (!GetConsoleScreenBufferInfo(hTerminal, &info))
+                return;
+
+            if (foreground != -1)
+            {
+                info.wAttributes &= ~(info.wAttributes & 0x0F);
+                info.wAttributes |= static_cast<WORD>(foreground);
+            }
+
+            if (background != -1)
+            {
+                info.wAttributes &= ~(info.wAttributes & 0xF0);
+                info.wAttributes |= static_cast<WORD>(background);
+            }
+
+            SetConsoleTextAttribute(hTerminal, info.wAttributes);
+        }
+    #endif // TERMCOLOR_OS_WINDOWS
+
+    } // namespace _internal
+
+} // namespace termcolor
+
+
+#undef TERMCOLOR_OS_WINDOWS
+#undef TERMCOLOR_OS_MACOS
+#undef TERMCOLOR_OS_LINUX
+
+#endif // TERMCOLOR_HPP_

--- a/src/cuckoo/gpu/kernel.cu
+++ b/src/cuckoo/gpu/kernel.cu
@@ -37,6 +37,7 @@
 #include "device_functions.h"
 #include "exceptions.h"
 #include "merit/nvml/nvml.h"
+#include "merit/termcolor/termcolor.hpp"
 #include <xmmintrin.h>
 #include <algorithm>
 #include <stdio.h>
@@ -1025,7 +1026,7 @@ std::unique_ptr<nvml::nvml_handle, int (*)(nvml::nvml_handle *)> initNVML(){
     auto nvml = std::unique_ptr<nvml::nvml_handle, int (*)(nvml::nvml_handle *)>(nvml::nvml_create(), nvml::nvml_destroy);
 
     if (nvml == nullptr)
-        std::cerr << "Failed to initialize NVML" << std::endl;
+        std::cerr << termcolor::red << "Failed to initialize NVML" << termcolor::reset << std::endl;
 
     return nvml;
 }
@@ -1052,13 +1053,13 @@ std::vector<merit::GPUInfo> GPUsInfo()
         // Get device
         auto nvmlres = nvml->nvmlDeviceGetHandleByIndex(index, &device);
         if (nvml::NVML_SUCCESS != nvmlres)
-            std::cerr << "Failed to get handle for device " << index << " " << nvml->nvmlErrorString(nvmlres) << std::endl;
+            std::cerr << termcolor::red << "Failed to get handle for device " << index << " " << nvml->nvmlErrorString(nvmlres) << termcolor::reset << std::endl;
 
         // Temperature
         unsigned int temp;
         nvmlres = nvml->nvmlDeviceGetTemperature(device, 0, &temp);
         if (nvml::NVML_SUCCESS != nvmlres){
-            std::cerr << "Failed to get temperature of device" << index << " " << nvml->nvmlErrorString(nvmlres) << std::endl;
+            std::cerr << termcolor::red << "Failed to get temperature of device" << index << " " << nvml->nvmlErrorString(nvmlres) << termcolor::reset << std::endl;
             item.temperature = -1;
         } else {
             item.temperature = temp;
@@ -1068,7 +1069,7 @@ std::vector<merit::GPUInfo> GPUsInfo()
         nvml::nvmlUtilization_t gpuUtil;
         nvmlres = nvml->nvmlDeviceGetUtilizationRates(device, &gpuUtil);
         if (nvml::NVML_SUCCESS != nvmlres){
-            std::cerr << "Failed to get utilization of device " << index << " : " << nvml->nvmlErrorString(nvmlres) << std::endl;
+            std::cerr << termcolor::red << "Failed to get utilization of device " << index << " : " << nvml->nvmlErrorString(nvmlres) << termcolor::reset << std::endl;
             item.gpu_util = -1;
             item.memory_util = -1;
         } else {
@@ -1080,7 +1081,7 @@ std::vector<merit::GPUInfo> GPUsInfo()
         unsigned int speed;
         nvmlres = nvml->nvmlDeviceGetFanSpeed(device, &speed);
         if (nvml::NVML_SUCCESS != nvmlres){
-            std::cerr << "Failed to get fan speed of device " <<  index <<  " : " << nvml->nvmlErrorString(nvmlres) << std::endl;
+            std::cerr << termcolor::red << "Failed to get fan speed of device " <<  index <<  " : " << nvml->nvmlErrorString(nvmlres) << termcolor::reset << std::endl;
             item.fan_speed = -1;
         } else {
             item.fan_speed = speed;

--- a/src/miner/miner.cpp
+++ b/src/miner/miner.cpp
@@ -264,7 +264,7 @@ namespace merit
                                 try {
                                     worker.run(); 
                                 } catch( std::exception& e) {
-                                    std::cout << "mining worker " << id << " error: " << e.what() << std::endl;
+                                    std::cerr << termcolor::red << "mining worker " << id << " error: " << e.what() << termcolor::reset << std::endl;
                                 }
                             }));
             }

--- a/src/miner/miner.cpp
+++ b/src/miner/miner.cpp
@@ -32,6 +32,7 @@
 #include "merit/cuckoo/mean_cuckoo.h"
 #include "merit/crypto/siphash.h"
 #include "merit/blake2/blake2.h"
+#include "merit/termcolor/termcolor.hpp"
 
 #include <chrono>
 #include <iostream>
@@ -178,9 +179,9 @@ namespace merit
             assert(threads_per_worker >= 0);
 
             _state = NotRunning;
-            std::cerr << "info: " << "workers: " << workers << std::endl;
-            std::cerr << "info: " << "threads per worker: " << threads_per_worker << std::endl;
-            std::cerr << "info: " << "gpu devices: " << gpu_devices.size() << std::endl;
+            std::cout << "info :: workers: " << termcolor::cyan << workers << termcolor::reset << std::endl;
+            std::cout << "info :: threads per worker: " << termcolor::cyan << threads_per_worker << termcolor::reset << std::endl;
+            std::cout << "info :: gpu devices: " << termcolor::cyan << gpu_devices.size() << termcolor::reset << std::endl;
 
             for(int i = 0; i < workers; i++) {
                 _workers.emplace_back(i, threads_per_worker, false, _pool, *this);
@@ -248,7 +249,7 @@ namespace merit
 
         void Miner::run()
         {
-            std::cerr << "info: " << "starting workers..." << std::endl;
+            std::cout << "info :: " << "starting workers..." << std::endl;
             using namespace std::chrono_literals;
             if(_state != NotRunning) {
                 return;
@@ -263,7 +264,7 @@ namespace merit
                                 try {
                                     worker.run(); 
                                 } catch( std::exception& e) {
-                                    std::cerr << "mining worker " << id << " error: " << e.what() << std::endl;
+                                    std::cout << "mining worker " << id << " error: " << e.what() << std::endl;
                                 }
                             }));
             }
@@ -271,12 +272,12 @@ namespace merit
             for(auto& j: jobs) { j.get();}
             _state = NotRunning;
 
-            std::cerr << "info: " << "stopped workers." << std::endl;
+            std::cout << "info :: " << "stopped workers." << std::endl;
         }
 
         void Miner::stop()
         {
-            std::cerr << "info: " << "stopping workers..." << std::endl;
+            std::cout << "info :: " << "stopping workers..." << std::endl;
             _state = Stopping;
         }
 
@@ -375,7 +376,7 @@ namespace merit
 
         void Worker::run()
         {
-            std::cerr << "info: " << "started worker: " << _id << std::endl;
+            std::cout << "info :: " << "started worker: " << _id << std::endl;
             using namespace std::chrono_literals;
             util::Work prev_work;
             uint32_t n =  0xffffffffU / _miner.total_workers() * _id;
@@ -489,7 +490,7 @@ namespace merit
 
                         std::string cycle_hash_hex;
                         util::to_hex(cycle_hash, cycle_hash_hex);
-                        std::cerr << "info: " << "(" << _id << ") found cycle (" << idx << "): " << cycle_hash_hex << std::endl;
+                        std::cout << "info :: " << termcolor::green << "(" << _id << ") found cycle (" << idx << "): " << cycle_hash_hex << termcolor::reset << std::endl;
                         if(target_test(cycle_hash, work->target)) {
                             stat.shares++;
                             _miner.submit_work(*work);
@@ -499,7 +500,7 @@ namespace merit
                 }
             }
             _state = NotRunning;
-            std::cerr << "info: " << "worker " << _id << " stopped..." << std::endl;
+            std::cout << "info :: " << "worker " << _id << " stopped..." << std::endl;
         }
     }
 }

--- a/src/minerd.cpp
+++ b/src/minerd.cpp
@@ -29,6 +29,7 @@
  * also delete it here.
  */
 #include <merit/miner.hpp>
+#include "merit/termcolor/termcolor.hpp"
 
 #include <iostream>
 #include <string>
@@ -90,7 +91,7 @@ int main(int argc, char** argv)
     }
 
     if(address.empty()) {
-        std::cout << "forgot to set your reward address. use --address" << std::endl;
+        std::cerr << "forgot to set your reward address. use --address" << std::endl;
         return 1;
     }
 
@@ -105,7 +106,7 @@ int main(int argc, char** argv)
     merit::set_agent(c.get(), "merit-minerd", "0.4");
 
     if(!merit::connect_stratum(c.get(), url.c_str(), address.c_str(), "")) {
-        std::cerr << "Error connecting" << std::endl;
+        std::cerr << termcolor::red << "Error connecting" << termcolor::reset << std::endl;
         return 1;
     }
     merit::run_stratum(c.get());
@@ -124,11 +125,16 @@ int main(int argc, char** argv)
         auto cyclesps = stats.total.cycles_per_second;
         auto sharesps = stats.total.shares_per_second;
         if(graphs > prev_graphs) {
-            std::cout << "graphs: " << graphs << " cycles: " << cycles << " shares: " << shares;
+            std::cout << "info :: graphs: " << termcolor::cyan << graphs << termcolor::reset
+                      << " cycles: " << termcolor::cyan << cycles << termcolor::reset
+                      << " shares: " << termcolor::cyan << shares << termcolor::reset;
             if(stats.total.attempts > 0) {
-                std::cout << " graphs/s: " << graphps << " cycles/s: " << cyclesps << " shares/s: " << sharesps << std::endl;
+                std::cout << " graphs/s: " << termcolor::cyan << graphps << termcolor::reset
+                          << " cycles/s: " << termcolor::cyan << cyclesps << termcolor::reset
+                          << " shares/s: " << termcolor::cyan << sharesps << termcolor::reset << std::endl;
+            } else {
+                std::cout << std::endl;
             }
-            std::cout << std::endl;
         }
         prev_graphs = graphs;
     }

--- a/src/minerd.cpp
+++ b/src/minerd.cpp
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
     }
 
     if(address.empty()) {
-        std::cerr << "forgot to set your reward address. use --address" << std::endl;
+        std::cerr << termcolor::red << "forgot to set your reward address. use -a or --address" << termcolor::reset << std::endl;
         return 1;
     }
 
@@ -103,7 +103,7 @@ int main(int argc, char** argv)
     auto info = merit::gpus_info();
     for(const auto& device: gpu_devices){
         if(device >= info.size() || device < 0){
-            std::cerr << "There is no GPU device with index = " << device << ". Please check available GPU devices by using --infogpu argument." << std::endl;
+            std::cerr << termcolor::red << "There is no GPU device with index = " << device << ". Please check available GPU devices by using --infogpu argument." << termcolor::reset << std::endl;
             return 1;
         }
     }

--- a/src/public.cpp
+++ b/src/public.cpp
@@ -87,7 +87,7 @@ namespace merit
     {
         assert(c);
 
-        std::cout << "info :: " << "connecting to: " << url << termcolor::reset << std::endl; 
+        std::cout << "info :: " << "connecting to: " << url << std::endl; 
         if(!c->stratum.connect(url, user, pass)) {
             std::cerr << termcolor::red << "error: " << "error connecting to stratum server: " << url << termcolor::reset << std::endl; 
             return false;
@@ -127,8 +127,8 @@ namespace merit
     {
         c->stratum.switch_pool();
 
-        std::cerr << std::endl << "error: " << "failed to connect to the pool= " << url << std::endl;
-        std::cout << "info: " << "reconnecting to another pool= " << c->stratum.get_url() << std::endl << std::endl;
+        std::cerr << std::endl << termcolor::red << "error: " << "failed to connect to the pool= " << url << termcolor::reset << std::endl;
+        std::cout << "info :: " << "reconnecting to another pool= " << c->stratum.get_url() << std::endl << std::endl;
 
         return connect_stratum(c, c->stratum.get_url().c_str(), user, pass);
     }

--- a/src/public.cpp
+++ b/src/public.cpp
@@ -31,6 +31,7 @@
 #include "merit/miner.hpp"
 #include "merit/stratum/stratum.hpp"
 #include "merit/miner/miner.hpp"
+#include "merit/termcolor/termcolor.hpp"
 
 #include <iostream>
 #include <memory>
@@ -80,21 +81,21 @@ namespace merit
     {
         assert(c);
 
-        std::cerr << "info: " << "connecting to: " << url<< std::endl; 
+        std::cout << "info :: " << "connecting to: " << url << termcolor::reset << std::endl; 
         if(!c->stratum.connect(url, user, pass)) {
-            std::cerr << "error: " << "error connecting to stratum server: " << url<< std::endl; 
+            std::cerr << termcolor::red << "error: " << "error connecting to stratum server: " << url << termcolor::reset << std::endl; 
             return false;
         }
 
-        std::cerr << "info: " << "subscribing to: " << url<< std::endl; 
+        std::cout << "info :: " << "subscribing to: " << url<< std::endl; 
         if(!c->stratum.subscribe()) {
-            std::cerr << "error: " << "error subscribing to stratum server: " << url<< std::endl; 
+            std::cerr << termcolor::red << "error: " << "error subscribing to stratum server: " << url << termcolor::reset << std::endl; 
             return false;
         }
 
-        std::cerr << "info: " << "authorizing as: " << user<< std::endl; 
+        std::cout << "info :: " << "authorizing as: " << user<< std::endl; 
         if(!c->stratum.authorize()) {
-            std::cerr << "error: " << "error authorize to stratum server: " << url<< std::endl; 
+            std::cerr << termcolor::red << "error: " << "error authorize to stratum server: " << url << termcolor::reset << std::endl; 
             return false;
         }
 
@@ -102,12 +103,12 @@ namespace merit
             c->stratum.submit_work(w);
         };
 
-        std::cerr << "info: " << "connected to: " << url<< std::endl; 
+        std::cout << "info :: " << termcolor::green << "connected to: " << url << termcolor::reset << std::endl; 
         return true;
     }
     catch(std::exception& e)
     {
-        std::cerr << "error: " << "error connecting to stratum server: " << e.what()<< std::endl; 
+        std::cerr << termcolor::red << "error: " << "error connecting to stratum server: " << e.what() << termcolor::reset << std::endl; 
         c->stratum.disconnect();
         return false;
     }
@@ -145,10 +146,10 @@ namespace merit
                 try {
                     c->stratum.run();
                 } catch(std::exception& e) {
-                std::cerr << "error: " << "error running stratum: " << e.what()<< std::endl; 
+                std::cerr << termcolor::red << "error: " << "error running stratum: " << e.what() << termcolor::reset << std::endl; 
                 }
                 c->stratum.disconnect();
-                std::cerr << "info: " << "stopped stratum."<< std::endl; 
+                std::cout << "info :: " << "stopped stratum."<< std::endl; 
         });
 
         return true;
@@ -157,7 +158,7 @@ namespace merit
     void stop_stratum(Context* c)
     {
         assert(c);
-        std::cerr << "info: " << "stopping stratum..."<< std::endl; 
+        std::cout << "info :: " << "stopping stratum..."<< std::endl; 
         c->stratum.stop();
     }
 
@@ -174,14 +175,14 @@ namespace merit
 
         c->miner.reset();
 
-        std::cerr << "info: " << "setting up miner..."<< std::endl; 
+        std::cout << "info :: " << "setting up miner..."<< std::endl; 
         c->miner = std::make_unique<miner::Miner>(
                 workers,
                 threads_per_worker,
                 gpu_devices,
                 c->submit_work_func);
 
-        std::cerr << "info: " << "starting miner..."<< std::endl; 
+        std::cout << "info :: " << "starting miner..."<< std::endl; 
         if(c->mining_thread.joinable()) {
             c->mining_thread.join();
         }
@@ -190,14 +191,14 @@ namespace merit
                     c->miner->run();
                 } catch(std::exception& e) {
                     c->miner->stop();
-                    std::cerr << "error: " << e.what() << std::endl;
+                    std::cerr << termcolor::red << "error: " << e.what() << termcolor::reset << std::endl;
 
                     return false;
                 }
         });
 
         //TODO: different logic depending on stratum vs solo
-        std::cerr << "info: " << "starting collab thread..."<< std::endl; 
+        std::cout << "info :: " << "starting collab thread..."<< std::endl; 
         if(c->collab_thread.joinable()) {
             c->collab_thread.join();
         }
@@ -217,7 +218,7 @@ namespace merit
                     c->miner->submit_job(*j);
 
                 } catch(std::exception& e) {
-                std::cerr << "error: " << "error getting job: " << e.what()<< std::endl; 
+                std::cerr << termcolor::red << "error: " << "error getting job: " << e.what() << termcolor::reset << std::endl; 
                     std::this_thread::sleep_for(50ms);
                 }
         });
@@ -225,7 +226,7 @@ namespace merit
     }
     catch(std::exception& e)
     {
-        std::cerr << "error: " << "error starting miners: " << e.what()<< std::endl; 
+        std::cerr << termcolor::red  << "error: " << "error starting miners: " << e.what() << termcolor::reset << std::endl; 
         return false;
     }
 

--- a/src/stratum/stratum.cpp
+++ b/src/stratum/stratum.cpp
@@ -29,6 +29,7 @@
  * also delete it here.
  */
 #include "merit/stratum/stratum.hpp"
+#include "merit/termcolor/termcolor.hpp"
 
 #include <chrono>
 #include <boost/property_tree/ptree.hpp>
@@ -87,7 +88,7 @@ namespace merit
                 const std::string& version)
         {
             _agent = software + "/" + version;
-            std::cerr << "setting agent to: " << _agent << std::endl;
+            std::cout << "info :: setting agent to: " << _agent << std::endl;
         }
 
         bool set_socket_opts(asio::ip::tcp::socket& sock)
@@ -105,7 +106,7 @@ namespace merit
                         &vals,
                         sizeof(vals),
                         NULL, 0, &outputBytes, NULL, NULL)) {
-                std::cerr << "error: " << "error setting keepalive" << std::endl;
+                std::cerr << termcolor::red << "error: " << "error setting keepalive" << termcolor::reset << std::endl;
                 return false;
             }
 #else
@@ -115,7 +116,7 @@ namespace merit
                         SO_KEEPALIVE,
                         &CKEEPALIVE,
                         sizeof(CKEEPALIVE))) {
-                std::cerr << "error: " << "error setting keepalive" << std::endl;
+                std::cerr << termcolor::red << "error: " << "error setting keepalive" << termcolor::reset << std::endl;
                 return false;
             }
 #ifdef __linux
@@ -125,7 +126,7 @@ namespace merit
                         TCP_KEEPCNT,
                         &CTCP_KEEPCNT,
                         sizeof(CTCP_KEEPCNT))) {
-                std::cerr << "error: " << "error setting keepcnt" << std::endl;
+                std::cerr << termcolor::red << "error: " << "error setting keepcnt" << termcolor::reset << std::endl;
                 return false;
             }
             if (setsockopt(
@@ -134,7 +135,7 @@ namespace merit
                         TCP_KEEPIDLE,
                         &CTCP_KEEPIDLE,
                         sizeof(CTCP_KEEPIDLE))) {
-                std::cerr << "error: " << "error setting keepidle" << std::endl;
+                std::cerr << termcolor::red << "error: " << "error setting keepidle" << termcolor::reset << std::endl;
                 return false;
             }
             if (setsockopt(
@@ -143,7 +144,7 @@ namespace merit
                         TCP_KEEPINTVL,
                         &CTCP_KEEPINTVL,
                         sizeof(CTCP_KEEPINTVL))) {
-                std::cerr << "error: " << "error setting keepintvl" << std::endl;
+                std::cerr << termcolor::red << "error: " << "error setting keepintvl" << termcolor::reset << std::endl;
                 return false;
             }
 #endif
@@ -154,7 +155,7 @@ namespace merit
                         TCP_KEEPALIVE,
                         &CTCP_KEEPINTVL,
                         sizeof(CTCP_KEEPINTVL))) {
-                std::cerr << "error: " << "error setting keepintvl" << std::endl;
+                std::cerr << termcolor::red << "error: " << "error setting keepintvl" << termcolor::reset << std::endl;
                 return false;
             }
 #endif
@@ -182,8 +183,8 @@ namespace merit
             _host = _url.substr(host_pos, port_pos - host_pos - 1);
             _port = _url.substr(port_pos);
 
-            std::cerr << "info: " << "host: " << _host << std::endl;
-            std::cerr << "info: " << "port: " << _port << std::endl;
+            std::cout << "info :: " << "host: " << _host << std::endl;
+            std::cout << "info :: " << "port: " << _port << std::endl;
 
 
             asio::ip::tcp::resolver resolver{_service};
@@ -236,7 +237,7 @@ namespace merit
         }
         catch(std::exception& e)
         {
-            std::cerr << "error: " << "error parsing json: " << e.what() << std::endl;
+            std::cerr << termcolor::red << "error :: " << "error parsing json: " << e.what() << termcolor::reset << std::endl;
             return false;
         }
 
@@ -338,7 +339,7 @@ namespace merit
             j.diff = _next_diff;
             j.clean = *is_clean;
             _new_job = true;
-            std::cerr << "info: " << "notify: " << j.id << " time: " << *time << " nbits: " << *nbits << " edgebits: " << j.nedgebits << " prevhash: " << *prevhash << std::endl;
+            std::cout << "info :: " << "notify: " << j.id << " time: " << *time << " nbits: " << *nbits << " edgebits: " << j.nedgebits << " prevhash: " << *prevhash << std::endl;
 
             _job = j;
 
@@ -354,7 +355,7 @@ namespace merit
             }
 
             _next_diff = *diff;
-            std::cerr << "info: " << "difficulty: " << *diff << std::endl;
+            std::cout << "info :: " << termcolor::yellow << "difficulty: " << *diff << termcolor::reset << std::endl;
             return true;
         }
 
@@ -399,7 +400,7 @@ namespace merit
             auto v = params.begin();
             auto msg = v->second.get_value_optional<std::string>(); v++;
             if(msg) {
-                std::cerr << "info: " << "message: " << *msg << std::endl;
+                std::cout << "info :: " << "message: " << termcolor::cyan << *msg  << termcolor::reset << std::endl;
             }
 
             return true;
@@ -415,39 +416,39 @@ namespace merit
 
             auto params = val.get_child_optional("params");
             if(!params) {
-                std::cerr << "error: " << "unable to get params from response" << std::endl;
+                std::cerr << termcolor::red << "error :: " << "unable to get params from response" << termcolor::reset << std::endl;
                 return false;
             }
 
             if(*method == "mining.notify") {
                 if(!mining_notify(*params)) {
-                    std::cerr << "error: " << "unable to set mining.notify" << std::endl;
+                    std::cerr << termcolor::red << "error :: " << "unable to set mining.notify" << termcolor::reset << std::endl;
                     return false;
                 }
             } else if(*method == "mining.set_difficulty") {
                 if(!mining_difficulty(*params)) {
-                    std::cerr << "error: " << "unable to set mining.difficulty" << std::endl;
+                    std::cerr << termcolor::red << "error :: " << "unable to set mining.difficulty" << termcolor::reset << std::endl;
                     return false;
                 }
             } else if(*method == "client.reconnect") {
                 if(!client_reconnect(*params)) {
-                    std::cerr << "error: " << "unable to execute client.reconnect" << std::endl;
+                    std::cerr << termcolor::red << "error :: " << "unable to execute client.reconnect" << termcolor::reset << std::endl;
                     return false;
                 }
             } else if(*method == "client.get_version") {
                 if(!id || !client_get_version(*id)) {
-                    std::cerr << "error: " << "unable to execute client.get_version" << std::endl;
+                    std::cerr << termcolor::red << "error :: " << "unable to execute client.get_version" << termcolor::reset << std::endl;
                     return false;
                 }
             } else if(*method == "client.show_message") {
                 if(!id) { return true; }
 
                 if(!client_show_message(*params, *id)) {
-                    std::cerr << "error: " << "unable to execute client.show_message" << std::endl;
+                    std::cerr << termcolor::red << "error :: " << "unable to execute client.show_message" << termcolor::reset << std::endl;
                     return false;
                 }
             } else {
-                std::cerr << "unknown method: '" << *method << "' message: " << res << std::endl;
+                std::cerr << termcolor::red << "error :: unknown method: '" << *method << "' message: " << res << termcolor::reset << std::endl;
             }
 
             return true;
@@ -460,7 +461,7 @@ namespace merit
             req << "{\"id\": 2, \"method\": \"mining.authorize\", \"params\": [\"" << _user << "\", \"" << _pass << "\"]}";
             if (!send(req.str()))
             {
-                std::cerr << "error: " << "error sending authorize request" << std::endl;
+                std::cerr << termcolor::red << "error :: " << "error sending authorize request" << termcolor::reset << std::endl;
                 return false;
             }
 
@@ -486,7 +487,7 @@ namespace merit
                     }
                 }
                 catch(std::exception e) {
-                    std::cerr << "error: " << "error reconnecting: " << e.what() << std::endl;
+                    std::cerr << termcolor::red << "error :: " << "error reconnecting: " << e.what() << termcolor::reset << std::endl;
                 }
 
                 if(!connected) {
@@ -497,7 +498,7 @@ namespace merit
                     auto t = min_reconnect_time * dist(_mt);
                     tries++;
 
-                    std::cerr << "error: " << "error connecting, reconnecting in " << t.count() << "ms..." << std::endl;
+                    std::cerr << termcolor::red << "error :: " << "error connecting, reconnecting in " << t.count() << "ms..." << termcolor::reset << std::endl;
                     std::this_thread::sleep_for(t);
                 }
             }
@@ -512,18 +513,18 @@ namespace merit
             try {
                 std::string res;
                 if(!recv(res)) {
-                    std::cerr << "error: " << "error receiving" << std::endl;
+                    std::cerr << termcolor::red << "error :: " << "error receiving" << termcolor::reset << std::endl;
                     throw std::runtime_error("error receiving");
                 }
                 if(_run_state == Running && _state == Disconnected) {
-                    std::cerr << "error: disconnected: " << std::endl;
+                    std::cerr << termcolor::red << "error :: disconnected: " << termcolor::reset << std::endl;
                     throw std::runtime_error("disconnected.");
                 }
 
                 pt::ptree val;
                 if(!parse_json(res, val)) {
                     _sockbuf.clear();
-                    std::cerr << "error parsing stratum response: " << res << std::endl;
+                    std::cerr << termcolor::red << "error :: error parsing stratum response: " << res << termcolor::reset << std::endl;
                     continue;
                 }
 
@@ -533,15 +534,15 @@ namespace merit
 
             } catch(std::exception& e) {
                 if(!reconnect()) {
-                    std::cerr << "error: " << "failed to reconnect" << std::endl;
+                    std::cerr << termcolor::red << "error :: " << "failed to reconnect" << termcolor::reset << std::endl;
                     return false;
                 } else if(_run_state == Running) {
-                    std::cerr << "info: reconnected!" << std::endl;
+                    std::cout << "info :: reconnected!" << std::endl;
                 }
             }
 
             _run_state = NotRunning;
-            std::cerr << "info: stratum stopped." << std::endl;
+            std::cout << "info :: stratum stopped." << std::endl;
 
             return true;
         }
@@ -616,10 +617,10 @@ namespace merit
                 << "\"" << cycle.str() << "\"], \"id\":4}";
 
             if(!send(req.str())) {
-                std::cerr << "error: " << "Error submitting work: " << req.str() << std::endl;
+                std::cerr << termcolor::red << "error :: " << "Error submitting work: " << req.str() << termcolor::reset << std::endl;
                 disconnect();
             } else {
-                std::cerr << "info: " << "submitted work: " << req.str() << std::endl;
+                std::cout << "info :: " << termcolor::green << "submitted work: " << req.str() << termcolor::reset << std::endl;
             }
         }
 
@@ -634,7 +635,7 @@ namespace merit
             }
 
             if (!send(req.str())) {
-                std::cerr << "error: " << "subscribe failed" << std::endl;
+                std::cerr << termcolor::red << "error :: " << "subscribe failed" << termcolor::reset << std::endl;
                 return false;
             }
             return subscribe_resp();
@@ -649,7 +650,7 @@ namespace merit
 
             pt::ptree resp;
             if(!parse_json(resp_line, resp)) {
-                std::cerr << "error: " << "error parsing response: " << resp_line << std::endl;
+                std::cerr << termcolor::red << "error :: " << "error parsing response: " << resp_line << termcolor::reset << std::endl;
                 return false;
             }
 
@@ -657,20 +658,20 @@ namespace merit
             if(!result) {
                 auto err = resp.get_optional<std::string>("error");
                 if(err) {
-                    std::cerr << "error: " << "subscribe error : " << *err << std::endl;
+                    std::cerr << termcolor::red << "error :: " << "subscribe error : " << *err << termcolor::reset << std::endl;
                 } else {
-                    std::cerr << "error: " << "unknown subscribe error" << std::endl;
+                    std::cerr << termcolor::red << "error :: " << "unknown subscribe error" << termcolor::reset << std::endl;
                 }
                 return false;
             }
 
             if(result->size() < 3) {
-                std::cerr << "error: " << "not enough values in response" << std::endl;
+                std::cerr << termcolor::red << "error :: " << "not enough values in response" << termcolor::reset << std::endl;
                 return false;
             }
 
             if(!find_session_id(*result, _session_id)) {
-                std::cerr << "error: " << "failed to find the session id" << std::endl;
+                std::cerr << termcolor::red << "error :: " << "failed to find the session id" << termcolor::reset << std::endl;
                 return false;
             }
 
@@ -679,27 +680,27 @@ namespace merit
 
             auto xnonce1 = res->second.get_value_optional<std::string>();
             if(!xnonce1) {
-                std::cerr << "error: " << "invalid extranonce" << std::endl;
+                std::cerr << termcolor::red << "error :: " << "invalid extranonce" << termcolor::reset << std::endl;
                 return false;
             }
 
             res++;
             auto xnonce2_size = res->second.get_value_optional<int>();
             if(!xnonce2_size) {
-                std::cerr << "error: " << "cannot parse extranonce size" << std::endl;
+                std::cerr << termcolor::red << "error :: " << "cannot parse extranonce size" << termcolor::reset << std::endl;
                 return false;
             }
 
             _xnonce2_size = *xnonce2_size;
 
             if (_xnonce2_size < 0 || _xnonce2_size > 100) {
-                std::cerr << "error: " << "invalid extranonce2 size" << std::endl;
+                std::cerr << termcolor::red << "error :: " << "invalid extranonce2 size" << termcolor::reset << std::endl;
                 return false;
             }
 
             _xnonce1.clear();
             if(!util::parse_hex(*xnonce1, _xnonce1)) {
-                std::cerr << "error: " << "error parsing extranonce1" << std::endl;
+                std::cerr << termcolor::red << "error :: " << "error parsing extranonce1" << termcolor::reset << std::endl;
             }
             _next_diff = 1.0;
 
@@ -732,7 +733,7 @@ namespace merit
                     boost::system::error_code error;
                     auto len = _socket.read_some(asio::buffer(s), error);
                     if(error && error != boost::asio::error::eof) {
-                        std::cerr << "error: " << "error receiving data: " << error << std::endl;
+                        std::cerr << termcolor::red << "error :: " << "error receiving data: " << error << termcolor::reset << std::endl;
                         return false;
                     }
 


### PR DESCRIPTION
Hey team! I hope this is a welcomed change and that it isn't too much at once.

Due to having tried tracking error messages down, etc when the miner is running I did some cleanup work and added [termcolor](https://github.com/ikalnytskyi/termcolor) for colorized outputs.

I added red coloring to all `std::cerr` error messages, and made sure all errors are sent to the error stream. Also changed most informational messages to use the standard `std::cout` stream so that the two streams can be directed to different outputs, which makes it easy to filter out only errors. 

I also colorized a few things that users may find important including stats, difficulty, stratum messages and other numeric information. 

I've only compiled this on linux, without an nvidia device present, but here's an example of what to expect:
![image](https://user-images.githubusercontent.com/760989/44763646-30bd1e80-ab1a-11e8-91e0-8238d9354753.png)

